### PR TITLE
feat/metric_building

### DIFF
--- a/models/marts/dim_customers.sql
+++ b/models/marts/dim_customers.sql
@@ -6,7 +6,7 @@ with customers as  (
 
 orders as  (
 
-    select * from {{ ref('stg_orders')}}
+    select * from {{ ref('stg_orders') }}
 
 ),
 
@@ -14,8 +14,14 @@ customer_first_last_order_at as (
 
     select
         customer_id,
-        first_value(orders.ordered_at) over(partition by orders.customer_id order by orders.ordered_at asc) as first_order_at,
-        last_value(orders.ordered_at) over(partition by orders.customer_id order by orders.ordered_at asc) as last_order_at
+        first_value(orders.ordered_at) over (
+            partition by orders.customer_id 
+            order by orders.ordered_at asc
+        ) as first_order_at,
+        last_value(orders.ordered_at) over (
+            partition by orders.customer_id 
+            order by orders.ordered_at asc
+        ) as last_order_at
     from orders
     --only consider complete (delivered) orders
     where orders.order_status = 'delivered'
@@ -48,8 +54,8 @@ final as (
     --boolean
         --customer considered active if they have made an order in the past 45 days
         case 
-            when days_since_first_last.days_since_last_order <= 45 then 1
-            else 0
+            when days_since_first_last.days_since_last_order <= 45 then true
+            else false
         end as is_active,
 
 

--- a/models/marts/dim_customers.sql
+++ b/models/marts/dim_customers.sql
@@ -1,5 +1,34 @@
 with customers as  (
-    select * from {{ ref('stg_customers' )}}
+
+    select * from {{ ref('stg_customers')}}
+
+),
+
+orders as  (
+
+    select * from {{ ref('stg_orders')}}
+
+),
+
+customer_first_last_order_at as (
+
+    select
+        customer_id,
+        first_value(orders.ordered_at) over(partition by orders.customer_id order by orders.ordered_at asc) as first_order_at,
+        last_value(orders.ordered_at) over(partition by orders.customer_id order by orders.ordered_at asc) as last_order_at
+    from orders
+    --only consider complete (delivered) orders
+    where orders.order_status = 'delivered'
+),
+
+days_since_first_last as (
+    
+    select
+        customer_id,
+        timestamp_diff(current_timestamp, customer_first_last_order_at.first_order_at, day) as days_since_first_order,
+        timestamp_diff(current_timestamp, customer_first_last_order_at.last_order_at, day) as days_since_last_order,
+        timestamp_diff(customer_first_last_order_at.last_order_at, customer_first_last_order_at.first_order_at, day) as days_between_first_last_order
+    from customer_first_last_order_at
 ),
 
 final as (
@@ -13,10 +42,23 @@ final as (
         customers.customer_zip_code_prefix,
         customers.customer_city,
         customers.customer_state,
+        days_since_first_last.days_since_first_order,
+        days_since_first_last.days_since_last_order,
+        days_since_first_last.days_between_first_last_order,
+    --boolean
+        --customer considered active if they have made an order in the past 45 days
+        case 
+            when days_since_first_last.days_since_last_order <= 45 then 1
+            else 0
+        end as is_active,
+
+
     -- database
         current_timestamp() as dbt_updated_at
 
     from customers
+    left join days_since_first_last
+        on customers.customer_id = days_since_first_last.customer_id
 )
 
 select * from final

--- a/models/marts/fct_order_items.sql
+++ b/models/marts/fct_order_items.sql
@@ -1,17 +1,25 @@
 with order_items as  (
+
     select * from {{ ref('stg_order_items' )}}
+
 ),
 
 orders as  (
+
     select * from {{ ref('stg_orders' )}}
+
 ),
 
 order_payments as  (
+
     select * from {{ ref('stg_order_payments' )}}
+
 ),
 
 reviews as (
+    
     select * from {{ ref('stg_order_reviews') }}
+
 ),
 
 final as (
@@ -33,17 +41,35 @@ final as (
     -- dimensions
         order_items.price,
         order_items.freight_value,
-        case when order_payments.payment_type is null then 'returned'
-            else orders.order_status end as order_status,
+        case 
+            when order_payments.payment_type is null then 'returned'
+            else orders.order_status 
+        end as order_status,
         coalesce(order_payments.payment_type, 'returned') as payment_type,
         coalesce(order_payments.payment_installments, 0) as payment_installments,
         coalesce(order_payments.payment_value, 0) as payment_amount,
         reviews.review_score,
+        timestamp_diff(orders.order_delivered_carrier_date, orders.ordered_at, day) as days_from_ordered_to_carrier,
+        timestamp_diff(orders.order_delivered_customer_date, orders.ordered_at, day) as days_from_ordered_to_delivered,
+        timestamp_diff(orders.order_delivered_customer_date, orders.order_delivered_carrier_date, day) as days_from_carrier_to_delivered,
+        case
+            when orders.order_status = 'delivered' 
+                and extract(day from orders.order_delivered_customer_date) = extract(day from orders.order_estimated_delivery_date) then 'on time'
+            when orders.order_status = 'delivered' 
+                and extract(day from orders.order_delivered_customer_date) > extract(day from orders.order_estimated_delivery_date) then 'late'
+            when orders.order_status = 'delivered' 
+                and extract(day from orders.order_delivered_customer_date) < extract(day from orders.order_estimated_delivery_date) then 'early'
+        end as order_delivery_status,
+
     -- booleans
-        case when order_payments.payment_installments > 1 then 1 
-            else 0 end as is_paid_with_installments,
-        case when reviews.review_score is not null then 1 
-            else 0 end as is_reviewed,
+        case 
+            when order_payments.payment_installments > 1 then 1 
+            else 0 
+        end as is_paid_with_installments,
+        case 
+            when reviews.review_score is not null then 1 
+            else 0 
+        end as is_reviewed,
     -- database
         current_timestamp() as dbt_updated_at
 

--- a/models/marts/fct_order_items.sql
+++ b/models/marts/fct_order_items.sql
@@ -41,10 +41,7 @@ final as (
     -- dimensions
         order_items.price,
         order_items.freight_value,
-        case 
-            when order_payments.payment_type is null then 'returned'
-            else orders.order_status 
-        end as order_status,
+        orders.order_status,
         coalesce(order_payments.payment_type, 'returned') as payment_type,
         coalesce(order_payments.payment_installments, 0) as payment_installments,
         coalesce(order_payments.payment_value, 0) as payment_amount,
@@ -54,21 +51,21 @@ final as (
         timestamp_diff(orders.order_delivered_customer_date, orders.order_delivered_carrier_date, day) as days_from_carrier_to_delivered,
         case
             when orders.order_status = 'delivered' 
-                and extract(day from orders.order_delivered_customer_date) = extract(day from orders.order_estimated_delivery_date) then 'on time'
+                and date(orders.order_delivered_customer_date) = date(orders.order_estimated_delivery_date) then 'on time'
             when orders.order_status = 'delivered' 
-                and extract(day from orders.order_delivered_customer_date) > extract(day from orders.order_estimated_delivery_date) then 'late'
+                and date(orders.order_delivered_customer_date) > date(orders.order_estimated_delivery_date) then 'late'
             when orders.order_status = 'delivered' 
-                and extract(day from orders.order_delivered_customer_date) < extract(day from orders.order_estimated_delivery_date) then 'early'
+                and date(orders.order_delivered_customer_date) < date(orders.order_estimated_delivery_date) then 'early'
         end as order_delivery_status,
 
     -- booleans
         case 
-            when order_payments.payment_installments > 1 then 1 
-            else 0 
+            when order_payments.payment_installments > 1 then true
+            else false
         end as is_paid_with_installments,
         case 
-            when reviews.review_score is not null then 1 
-            else 0 
+            when reviews.review_score is not null then true
+            else false
         end as is_reviewed,
     -- database
         current_timestamp() as dbt_updated_at

--- a/models/staging/ecommerce/stg_order_items.sql
+++ b/models/staging/ecommerce/stg_order_items.sql
@@ -1,7 +1,10 @@
 with order_items as (
 
     select
-        {{ dbt_utils.surrogate_key(['order_item_id', 'order_id']) }} as order_item_sk, 
+        {{ dbt_utils.surrogate_key([
+            'order_item_id', 
+            'order_id'
+        ]) }} as order_item_sk, 
         *
     from {{ source('ecommerce', 'order_items')}}
 


### PR DESCRIPTION
It has been a while but we are back! Needed to refresh myself a bit on the original proposed metrics. Elaborated and built out 2 of the original 3 I scoped out. 

**Metric:**  customer age
Rather than simply deriving days between first and last order, I thought it would add value to create `days_since_first_order`, `days_since_last_order` and `days_between_first_and_last`. As well an `is_active` bool that is determined by a certain threshold `days_since_last_order`

I believe these metrics provide more value than the original proposal for the marketing team. 
`days_since_first_order` can be used to determine out longest standing customers for certain marketing analysis or potential campaigns 
`days_since_last_order` can help determine the current state of a customer, if they are current or not
`days_between_first_and_last` can help determine how long a customer has been making orders with our company


**Metric:**  time to deliver
Again, rather than simply providing time to deliver, I thought it would add value to add:
`days_from_ordered_to_carrier` - help determine how quickly we are getting orders out to our carriers 
`days_from_ordered_to_delivered` - help track total time to delivery
`days_from_carrier_to_delivered` - help track performance of the carrier
`order_delivery_status` - track how well we are delivering vs our estimates